### PR TITLE
Fix Blob Env Variable Names

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -172,11 +172,11 @@ INBOX_ADDRESS=0x28047B039241A5b9518044c7c8755F53cbC47e53
 # Comma-delineated list (no spaces) of prover endpoints proposer should query when attempting to propose a block
 # If you keep this default value you must also enable a prover by setting ENABLE_PROVER=false
 # Whether to send EIP-4844 blob transactions when proposing blocks.
-BLOB_ALLOWED=true
+L1_BLOB_ALLOWED=true
 # Comma-delimited local tx pool addresses you want to prioritize, useful to set your proposer to only propose blocks with your prover's transactions.
 TXPOOL_LOCALS=
 # If set to true, the proposer will use calldata as DA when the blob fee is more expensive than using calldata.
-FALLBACK_TO_CALLDATA=
+L1_FALLBACK_TO_CALLDATA=
 # If set to true, enable revert protection. When you are not the first taiko proposer in current L1 block, you would revert.
 # This function must be supported by your PBS provider to be effective.
 REVERT_PROTECTION=

--- a/.env.hoodi
+++ b/.env.hoodi
@@ -118,7 +118,7 @@ INBOX_ADDRESS=0x4d469D3c2D17252A688da5613571A43a109F4F89
 # Comma-delineated list (no spaces) of prover endpoints proposer should query when attempting to propose a block
 # If you keep this default value you must also enable a prover by setting ENABLE_PROVER=false
 # Whether to send EIP-4844 blob transactions when proposing blocks.
-BLOB_ALLOWED=true
+L1_BLOB_ALLOWED=true
 # Minimum tip (in GWei) for a transaction to propose.
 EPOCH_MIN_TIP=
 # Time interval to propose L2 pending transactions

--- a/script/start-proposer.sh
+++ b/script/start-proposer.sh
@@ -52,30 +52,6 @@ if [ "$ENABLE_PROPOSER" = "true" ]; then
         ARGS="${ARGS} --surge.priceFluctuationModifier ${SURGE_PRICE_FLUCTUATION_MODIFIER}"
     fi
 
-    if [ -n "$CHECK_PROFITABILITY" ]; then
-        ARGS="${ARGS} --checkProfitability=${CHECK_PROFITABILITY}"
-    fi
-
-    if [ -n "$ALLOW_EMPTY_BLOCKS" ]; then
-        ARGS="${ARGS} --allowEmptyBlocks=${ALLOW_EMPTY_BLOCKS}"
-    fi
-
-    if [ -n "$SURGE_PROPOSING_BLOCK_GAS" ]; then
-        ARGS="${ARGS} --surge.gasNeededForProposingBlock ${SURGE_PROPOSING_BLOCK_GAS}"
-    fi
-
-    if [ -n "$SURGE_PROVING_BLOCK_GAS" ]; then
-        ARGS="${ARGS} --surge.gasNeededForProvingBlock ${SURGE_PROVING_BLOCK_GAS}"
-    fi
-
-    if [ -n "$SURGE_OFF_CHAIN_COSTS" ]; then
-        ARGS="${ARGS} --surge.offChainCosts ${SURGE_OFF_CHAIN_COSTS}"
-    fi
-
-    if [ -n "$SURGE_PRICE_FLUCTUATION_MODIFIER" ]; then
-        ARGS="${ARGS} --surge.priceFluctuationModifier ${SURGE_PRICE_FLUCTUATION_MODIFIER}"
-    fi
-
     if [ -n "$EPOCH_INTERVAL" ]; then
         ARGS="${ARGS} --epoch.interval ${EPOCH_INTERVAL}"
     fi

--- a/script/start-proposer.sh
+++ b/script/start-proposer.sh
@@ -105,11 +105,11 @@ if [ "$ENABLE_PROPOSER" = "true" ]; then
         ARGS="${ARGS} --txPool.locals ${TXPOOL_LOCALS}"
     fi
 
-    if [ "$BLOB_ALLOWED" == "true" ]; then
+    if [ "$L1_BLOB_ALLOWED" == "true" ]; then
         ARGS="${ARGS} --l1.blobAllowed"
     fi
 
-    if [ "$FALLBACK_TO_CALLDATA" == "true" ]; then
+    if [ "$L1_FALLBACK_TO_CALLDATA" == "true" ]; then
         ARGS="${ARGS} --l1.fallbackToCalldata"
     fi
 


### PR DESCRIPTION
While debugging locally, the blobAllowed was shown as false, even though it was being passed in the command line:

```
Starting proposer ARGS=--l1.ws ws://host.docker.internal:32004
        --l2.http http://l2-nethermind-execution-client:8547
        --l2.auth http://l2-nethermind-execution-client:8552
        --taikoInbox 0xb741f03967455Aad5AD9fBA7C29FDdc576a44343
        --taikoAnchor 0x7633740000000000000000000000000000010001
        --jwtSecret /tmp/jwt/jwtsecret
        --l1.proposerPrivKey 0x94eb3102993b41ec55c241060f47daa0f6372e2e3ad7e91612ae36c364042e44
        --l2.suggestedFeeRecipient 0xD51a7E12997f6f1D04AcCC2b4053307a62b373cb
        --inbox 0x28047B039241A5b9518044c7c8755F53cbC47e53
        --bridge 0xB6662a4E54F50841d45623e00d91004401a3Fd26
        --taikoWrapper 0x22519d2eDDFa697942C3C7E310F105B5b1C86518
        --forcedInclusionStore 0x2eb27A5Be6CCE84a69d09503Aa5c4d17C4F2C5f6
        --metrics true
        --metrics.port 6061 --checkProfitability=true --allowEmptyBlocks=false --checkProfitability=true --allowEmptyBlocks=false --epoch.interval 5s --l1.blobAllowed --tx.gasLimit 1000000 --tx.notInMempoolTimeout 30s --tx.resubmissionTimeout 10s

INFO [07-07|11:41:07.095] 
INFO [07-07|11:41:07.095] Using the transaction builder with fallback blobAllowed=false fallback=false
```

After making these changes:
```
Starting proposer ARGS=--l1.ws ws://host.docker.internal:32004
        --l2.http http://l2-nethermind-execution-client:8547
        --l2.auth http://l2-nethermind-execution-client:8552
        --taikoInbox 0xb741f03967455Aad5AD9fBA7C29FDdc576a44343
        --taikoAnchor 0x7633740000000000000000000000000000010001
        --jwtSecret /tmp/jwt/jwtsecret
        --l1.proposerPrivKey 0x94eb3102993b41ec55c241060f47daa0f6372e2e3ad7e91612ae36c364042e44
        --l2.suggestedFeeRecipient 0xD51a7E12997f6f1D04AcCC2b4053307a62b373cb
        --inbox 0x28047B039241A5b9518044c7c8755F53cbC47e53
        --bridge 0xB6662a4E54F50841d45623e00d91004401a3Fd26
        --taikoWrapper 0x22519d2eDDFa697942C3C7E310F105B5b1C86518
        --forcedInclusionStore 0x2eb27A5Be6CCE84a69d09503Aa5c4d17C4F2C5f6
        --metrics true
        --metrics.port 6061 --checkProfitability=true --allowEmptyBlocks=false --checkProfitability=true --allowEmptyBlocks=false --epoch.interval 5s --l1.blobAllowed --tx.gasLimit 1000000 --tx.notInMempoolTimeout 30s --tx.resubmissionTimeout 10s

INFO [07-07|11:55:15.250] 
INFO [07-07|11:55:15.250] Using the transaction builder with fallback blobAllowed=true fallback=false
```

The exact environment names are listed here: https://github.com/NethermindEth/surge-taiko-mono/blob/main-pacaya-v1.6.1/packages/taiko-client/cmd/flags/proposer.go#L88