### PR TITLE
Fix NMC Shutdown

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,6 @@ services:
     environment:
       TAIKO_INBOX: ${TAIKO_INBOX}
     entrypoint:
-      - /bin/sh
-      - -c
       - "/script/start-nethermind.sh"
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
NMC docker container does not shut down when using `docker stop` and eventually force kills after grace period timeout. This is due to nmc not running as pid 1:

```
docker exec l2-nethermind-execution-client ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   2804  1696 pts/0    Ss+  08:43   0:00 /bin/sh -c /script/start-nethermind.sh
root           7  1.3  0.3 282785948 227088 pts/0 Sl+ 08:43   0:02 ./Nethermind.Runner --Discovery.Bootno.....
```

By using the script directly, nmc starts as pid 1 and shutdowns immediately once the SIGTERM signal is received from `docker stop`:

```
docker exec l2-nethermind-execution-client ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  7.3  0.3 281237236 234428 pts/0 Ssl+ 09:24   0:01 ./Nethermind.Runner --Discovery.Bootnodes...
```