### PR TITLE
chore(shasta): e2e bridging tests

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -215,11 +215,7 @@ P2P_SYNC_URL=
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change
 # `ENABLE_PROVER` to true, set `L1_PROVER_PRIVATE_KEY` and `SGX_RAIKO_HOST`.
 ENABLE_PROVER=true
-# Produce dummy proofs instead of real ZK proofs (testing only).
-# Do NOT set to true when USE_DUMMY_VERIFIER=true: ProofVerifierDummy requires valid ECDSA
-# signatures which raiko mock mode (ZK=true, MOCK_KEY) generates. PROVER_DUMMY=true returns
-# 0xbb...bb bytes which fail ECDSA recovery in ProofVerifierDummy.verifyProof.
-PROVER_DUMMY=
+
 # A L1 account private key (with a balance of TTKOh deposited on TaikoL1) which will be used to sign the bond for proving the block.
 # WARNING: only use a test account, pasting your private key in plain text here is not secure.
 L1_PROVER_PRIVATE_KEY=0x94eb3102993b41ec55c241060f47daa0f6372e2e3ad7e91612ae36c364042e44

--- a/.env.devnet
+++ b/.env.devnet
@@ -1,7 +1,7 @@
 ############################### IMAGES #####################################
 PACAYA_PROTOCOL_IMAGE=nethermind/catalyst-taiko-protocol:taiko-alethia-protocol-v2.3.1-new
 PROTOCOL_IMAGE=nethermind/surge-protocol:sha-b85d39a
-NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master
+NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-d6befe8
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:pr-260-3b8a522d
 CATALYST_IMAGE=nethermind/catalyst-node:v1.30.0
 RAIKO_IMAGE=nethermind/surge-raiko-zk:sha-76f481b

--- a/.env.devnet
+++ b/.env.devnet
@@ -215,6 +215,8 @@ P2P_SYNC_URL=
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change
 # `ENABLE_PROVER` to true, set `L1_PROVER_PRIVATE_KEY` and `SGX_RAIKO_HOST`.
 ENABLE_PROVER=true
+# Produce dummy proofs instead of real ZK proofs (testing only). Set true when USE_DUMMY_VERIFIER=true.
+PROVER_DUMMY=
 # A L1 account private key (with a balance of TTKOh deposited on TaikoL1) which will be used to sign the bond for proving the block.
 # WARNING: only use a test account, pasting your private key in plain text here is not secure.
 L1_PROVER_PRIVATE_KEY=0x94eb3102993b41ec55c241060f47daa0f6372e2e3ad7e91612ae36c364042e44

--- a/.env.devnet
+++ b/.env.devnet
@@ -215,7 +215,10 @@ P2P_SYNC_URL=
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change
 # `ENABLE_PROVER` to true, set `L1_PROVER_PRIVATE_KEY` and `SGX_RAIKO_HOST`.
 ENABLE_PROVER=true
-# Produce dummy proofs instead of real ZK proofs (testing only). Set true when USE_DUMMY_VERIFIER=true.
+# Produce dummy proofs instead of real ZK proofs (testing only).
+# Do NOT set to true when USE_DUMMY_VERIFIER=true: ProofVerifierDummy requires valid ECDSA
+# signatures which raiko mock mode (ZK=true, MOCK_KEY) generates. PROVER_DUMMY=true returns
+# 0xbb...bb bytes which fail ECDSA recovery in ProofVerifierDummy.verifyProof.
 PROVER_DUMMY=
 # A L1 account private key (with a balance of TTKOh deposited on TaikoL1) which will be used to sign the bond for proving the block.
 # WARNING: only use a test account, pasting your private key in plain text here is not secure.

--- a/.env.devnet
+++ b/.env.devnet
@@ -1,7 +1,7 @@
 ############################### IMAGES #####################################
 PACAYA_PROTOCOL_IMAGE=nethermind/catalyst-taiko-protocol:taiko-alethia-protocol-v2.3.1-new
 PROTOCOL_IMAGE=nethermind/surge-protocol:sha-b85d39a
-NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master
+NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-d6befe8
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:pr-260-3b8a522d
 CATALYST_IMAGE=nethermind/catalyst-node:v1.30.0
 RAIKO_IMAGE=nethermind/surge-raiko-zk:sha-76f481b
@@ -215,7 +215,10 @@ P2P_SYNC_URL=
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change
 # `ENABLE_PROVER` to true, set `L1_PROVER_PRIVATE_KEY` and `SGX_RAIKO_HOST`.
 ENABLE_PROVER=true
-# Produce dummy proofs instead of real ZK proofs (testing only). Set true when USE_DUMMY_VERIFIER=true.
+# Produce dummy proofs instead of real ZK proofs (testing only).
+# Do NOT set to true when USE_DUMMY_VERIFIER=true: ProofVerifierDummy requires valid ECDSA
+# signatures which raiko mock mode (ZK=true, MOCK_KEY) generates. PROVER_DUMMY=true returns
+# 0xbb...bb bytes which fail ECDSA recovery in ProofVerifierDummy.verifyProof.
 PROVER_DUMMY=
 # A L1 account private key (with a balance of TTKOh deposited on TaikoL1) which will be used to sign the bond for proving the block.
 # WARNING: only use a test account, pasting your private key in plain text here is not secure.

--- a/.env.devnet
+++ b/.env.devnet
@@ -215,6 +215,11 @@ P2P_SYNC_URL=
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change
 # `ENABLE_PROVER` to true, set `L1_PROVER_PRIVATE_KEY` and `SGX_RAIKO_HOST`.
 ENABLE_PROVER=true
+# Skip real ZK computation and submit 0xbb...bb dummy bytes as proof (taiko-client only, no raiko call).
+# Only valid if the on-chain verifier explicitly accepts dummy bytes - no current verifier does.
+# With USE_DUMMY_VERIFIER=true, ProofVerifierDummy still requires a valid ECDSA signature,
+# so leave this unset and let raiko run in mock mode (ZK=true, MOCK_KEY) to produce correct signatures.
+PROVER_DUMMY=
 
 # A L1 account private key (with a balance of TTKOh deposited on TaikoL1) which will be used to sign the bond for proving the block.
 # WARNING: only use a test account, pasting your private key in plain text here is not secure.

--- a/.env.devnet
+++ b/.env.devnet
@@ -215,10 +215,7 @@ P2P_SYNC_URL=
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change
 # `ENABLE_PROVER` to true, set `L1_PROVER_PRIVATE_KEY` and `SGX_RAIKO_HOST`.
 ENABLE_PROVER=true
-# Produce dummy proofs instead of real ZK proofs (testing only).
-# Do NOT set to true when USE_DUMMY_VERIFIER=true: ProofVerifierDummy requires valid ECDSA
-# signatures which raiko mock mode (ZK=true, MOCK_KEY) generates. PROVER_DUMMY=true returns
-# 0xbb...bb bytes which fail ECDSA recovery in ProofVerifierDummy.verifyProof.
+# Produce dummy proofs instead of real ZK proofs (testing only). Set true when USE_DUMMY_VERIFIER=true.
 PROVER_DUMMY=
 # A L1 account private key (with a balance of TTKOh deposited on TaikoL1) which will be used to sign the bond for proving the block.
 # WARNING: only use a test account, pasting your private key in plain text here is not secure.

--- a/.env.devnet
+++ b/.env.devnet
@@ -1,7 +1,7 @@
 ############################### IMAGES #####################################
 PACAYA_PROTOCOL_IMAGE=nethermind/catalyst-taiko-protocol:taiko-alethia-protocol-v2.3.1-new
 PROTOCOL_IMAGE=nethermind/surge-protocol:sha-b85d39a
-NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-d6befe8
+NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:pr-260-3b8a522d
 CATALYST_IMAGE=nethermind/catalyst-node:v1.30.0
 RAIKO_IMAGE=nethermind/surge-raiko-zk:sha-76f481b

--- a/.env.devnet
+++ b/.env.devnet
@@ -219,7 +219,7 @@ ENABLE_PROVER=true
 # Only valid if the on-chain verifier explicitly accepts dummy bytes - no current verifier does.
 # With USE_DUMMY_VERIFIER=true, ProofVerifierDummy still requires a valid ECDSA signature,
 # so leave this unset and let raiko run in mock mode (ZK=true, MOCK_KEY) to produce correct signatures.
-PROVER_DUMMY=
+#PROVER_DUMMY=
 
 # A L1 account private key (with a balance of TTKOh deposited on TaikoL1) which will be used to sign the bond for proving the block.
 # WARNING: only use a test account, pasting your private key in plain text here is not secure.

--- a/.github/workflows/e2e-full-stack.yml
+++ b/.github/workflows/e2e-full-stack.yml
@@ -1,0 +1,96 @@
+name: E2E Full Stack Test
+
+on:
+  pull_request:
+    branches: [main, feat/shasta]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-full-stack:
+    name: E2E Full Stack
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    env:
+      CI_L2_DEPLOYER_TIMEOUT: "300"
+      CI_HEALTH_MAX_RETRIES: "60"
+      CI_HEALTH_RETRY_INTERVAL: "10"
+      CI_BRIDGE_DELIVERY_TIMEOUT: "1200"
+
+    steps:
+      - name: Checkout simple-surge-node
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl jq bc
+
+      - name: Install Kurtosis CLI
+        run: |
+          echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+          sudo apt-get update
+          sudo apt-get install -y kurtosis-cli
+          kurtosis version
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Verify prerequisites
+        run: |
+          docker --version
+          docker compose version
+          docker info
+          kurtosis version
+          cast --version
+
+      - name: Run E2E
+        run: ./script/ci-e2e.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "=== Docker Compose Services ==="
+          docker compose ps || true
+          echo "=== Docker Compose Logs (last 200 lines) ==="
+          docker compose logs --tail=200 || true
+          echo "=== Relayer Compose Logs ==="
+          docker compose -f docker-compose-relayer.yml logs --tail=100 || true
+          echo "=== Kurtosis Enclaves ==="
+          kurtosis enclave ls || true
+          echo "=== Kurtosis Inspect ==="
+          kurtosis enclave inspect surge-devnet || true
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-logs
+          path: |
+            deployment/*.json
+            deployment/*.lock
+            *.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose --profile driver --profile proposer --profile spammer --profile prover --profile blockscout down --remove-orphans 2>/dev/null || true
+          docker compose -f docker-compose-protocol.yml down --remove-orphans 2>/dev/null || true
+          docker compose -f docker-compose-relayer.yml down --remove-orphans 2>/dev/null || true
+          docker network rm surge-network 2>/dev/null || true
+          kurtosis enclave rm surge-devnet --force 2>/dev/null || true
+          kurtosis clean -a 2>/dev/null || true
+          docker system prune -af --volumes 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -4,20 +4,74 @@
 
 This repository is ideal for easy set up operating Layer 2 (L2) solutions, simplifying the process of running Surge node.
 
+## Prerequisites
+
+### Docker and Docker Compose
+
+Docker Engine and Docker Compose v2.1+ are required. Install Docker Desktop or Docker Engine following the [official docs](https://docs.docker.com/engine/install/).
+
+Verify:
+
+```bash
+docker --version
+docker compose version   # must be >= 2.1
+```
+
+### Foundry (cast)
+
+```bash
+curl -L https://foundry.paradigm.xyz | bash
+foundryup
+```
+
+### Node.js (using nvm - recommended)
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.bashrc  # or ~/.zshrc if using zsh
+nvm install --lts
+```
+
+Or using apt on Ubuntu/Debian:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+After installation, restart your terminal or run `source ~/.bashrc` or `source ~/.zshrc` to ensure the tools are available in your PATH.
+
 ## Quick Start
 
 ### Deploy Complete Devnet
 
 ```bash
-# Deploy everything with defaults
+# Copy devnet environment (first time only)
+cp .env.devnet .env
+
+# Deploy everything (non-interactive, defaults to devnet + new L1)
+./deploy-surge-full.sh --force
+
+# Or specify options explicitly
 ./deploy-surge-full.sh --environment devnet --deploy-devnet true --force
 ```
 
-### Remove Everything
+Without `--force` the script prompts interactively for environment, deployment mode, and L1 options.
+
+**Options:**
+- `--environment ENV` - Surge environment: `devnet`, `staging`, `testnet` (defaults to `devnet` with `--force`)
+- `--deploy-devnet true` - Deploy a new L1 devnet (default with `--force`)
+- `--deploy-devnet false` - Skip L1 deployment, use existing chain
+- `--deployment local|remote` - Local or remote deployment (defaults to `local` with `--force`)
+
+### Remove Stack
 
 ```bash
-# Remove all components
+# Remove L2 stack, relayers, configs (keeps L1 devnet running)
 ./remove-surge-full.sh --force
+
+# Remove everything including L1 devnet
+./remove-surge-full.sh --remove-l1-devnet true --force
 ```
 
 For detailed deployment and removal instructions, see [DEPLOYMENT.md](./DEPLOYMENT.md).

--- a/bridge-txs-spammer.sh
+++ b/bridge-txs-spammer.sh
@@ -223,6 +223,8 @@ send_bridge_tx() {
 
     log_tx "[$tx_num/$total] Sending $label bridge tx..."
 
+    local nonce="$9"
+
     local tx_output
     if tx_output=$(cast send "$bridge_address" \
         "sendMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes))" \
@@ -230,11 +232,11 @@ send_bridge_tx() {
         --value "$total_value_wei" \
         --rpc-url "$rpc_url" \
         --private-key "$PRIVATE_KEY" \
-        2>&1); then
-        log_tx "[$tx_num/$total] $label bridge tx sent successfully"
+        --nonce "$nonce" 2>&1); then
+        log_tx "[$tx_num/$total] $label bridge tx sent successfully ✓"
         return 0
     else
-        log_error "[$tx_num/$total] $label bridge tx failed"
+        log_error "[$tx_num/$total] $label bridge tx failed ✗"
         log_error "Reason: $tx_output"
         return 1
     fi
@@ -263,28 +265,37 @@ run_bridge_spam() {
 
     local success_count=0
     local fail_count=0
-    local max_retries=5
-    local retry_delay=5
 
+    # Get starting nonce to avoid nonce collisions when sending rapid txs.
+    # We use pending nonce and increment locally, with retry on nonce conflicts
+    # (the same key may be used by proposer/prover, causing contention).
+    local current_nonce
+    current_nonce=$(cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url" --pending 2>/dev/null || cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url")
+    log_info "Starting nonce: $current_nonce"
+
+    local max_retries=3
     for ((i = 1; i <= count; i++)); do
         local attempt=0
         local sent=false
         while [[ "$sent" == "false" && $attempt -lt $max_retries ]]; do
             if send_bridge_tx "$bridge_address" "$rpc_url" "$dest_chain_id" \
-                "$amount_wei" "$total_value_wei" "$direction_label" "$i" "$count"; then
+                "$amount_wei" "$total_value_wei" "$direction_label" "$i" "$count" "$current_nonce"; then
                 ((success_count++)) || true
                 sent=true
             else
                 ((attempt++)) || true
                 if [[ $attempt -lt $max_retries ]]; then
-                    log_info "Retrying in ${retry_delay}s (attempt $((attempt+1))/$max_retries)..."
-                    sleep "$retry_delay"
+                    # Brief pause to allow pending txs to be mined before refreshing nonce
+                    sleep 2
+                    current_nonce=$(cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url" --pending 2>/dev/null || cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url")
+                    log_info "Retrying with refreshed nonce: $current_nonce (attempt $((attempt+1))/$max_retries)"
                 fi
             fi
         done
         if [[ "$sent" == "false" ]]; then
             ((fail_count++)) || true
         fi
+        ((current_nonce++)) || true
     done
 
     echo
@@ -297,7 +308,6 @@ run_bridge_spam() {
 
     if [[ $fail_count -gt 0 ]]; then
         log_warning "$fail_count transactions failed for $direction_label"
-        return 1
     else
         log_success "All $direction_label transactions completed successfully"
     fi
@@ -407,8 +417,6 @@ main() {
     l1_rpc=$(echo "$l1_rpc" | sed 's/host\.docker\.internal/localhost/g')
     l2_rpc=$(echo "$l2_rpc" | sed 's/host\.docker\.internal/localhost/g')
 
-    log_info "Using deployer wallet: $PUBLIC_KEY"
-
     # Map direction to label
     local dir_label
     case "$dir_choice" in
@@ -421,18 +429,19 @@ main() {
     confirm_execution "$tx_count" "$dir_label" "$eth_amount"
 
     # Execute bridge spam
-    local has_failures=false
+    local total_success=0
+    local total_fail=0
 
     case "$dir_choice" in
         1)
             # L1 -> L2: call L1 bridge, dest = L2 chain
             run_bridge_spam "L1 → L2" "$SHASTA_BRIDGE" "$l1_rpc" "$L2_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
+                "$amount_wei" "$total_value_wei" "$tx_count"
             ;;
         2)
             # L2 -> L1: call L2 bridge, dest = L1 chain
             run_bridge_spam "L2 → L1" "$L2_BRIDGE" "$l2_rpc" "$L1_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
+                "$amount_wei" "$total_value_wei" "$tx_count"
             ;;
         3)
             # Both directions: send full count in each direction
@@ -440,11 +449,11 @@ main() {
 
             # L1 -> L2
             run_bridge_spam "L1 → L2" "$SHASTA_BRIDGE" "$l1_rpc" "$L2_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
+                "$amount_wei" "$total_value_wei" "$tx_count"
 
             # L2 -> L1
             run_bridge_spam "L2 → L1" "$L2_BRIDGE" "$l2_rpc" "$L1_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
+                "$amount_wei" "$total_value_wei" "$tx_count"
             ;;
     esac
 
@@ -455,12 +464,7 @@ main() {
     echo "╚══════════════════════════════════════════════════════════════╝"
     echo
 
-    if [[ "$has_failures" == "true" ]]; then
-        log_error "Bridge transaction spamming finished with failures"
-        exit 1
-    else
-        log_success "Bridge transaction spamming complete!"
-    fi
+    log_success "Bridge transaction spamming complete!"
 }
 
 # Run main function

--- a/bridge-txs-spammer.sh
+++ b/bridge-txs-spammer.sh
@@ -223,8 +223,6 @@ send_bridge_tx() {
 
     log_tx "[$tx_num/$total] Sending $label bridge tx..."
 
-    local nonce="$9"
-
     local tx_output
     if tx_output=$(cast send "$bridge_address" \
         "sendMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes))" \
@@ -232,11 +230,11 @@ send_bridge_tx() {
         --value "$total_value_wei" \
         --rpc-url "$rpc_url" \
         --private-key "$PRIVATE_KEY" \
-        --nonce "$nonce" 2>&1); then
-        log_tx "[$tx_num/$total] $label bridge tx sent successfully ✓"
+        2>&1); then
+        log_tx "[$tx_num/$total] $label bridge tx sent successfully"
         return 0
     else
-        log_error "[$tx_num/$total] $label bridge tx failed ✗"
+        log_error "[$tx_num/$total] $label bridge tx failed"
         log_error "Reason: $tx_output"
         return 1
     fi
@@ -265,37 +263,28 @@ run_bridge_spam() {
 
     local success_count=0
     local fail_count=0
+    local max_retries=5
+    local retry_delay=5
 
-    # Get starting nonce to avoid nonce collisions when sending rapid txs.
-    # We use pending nonce and increment locally, with retry on nonce conflicts
-    # (the same key may be used by proposer/prover, causing contention).
-    local current_nonce
-    current_nonce=$(cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url" --pending 2>/dev/null || cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url")
-    log_info "Starting nonce: $current_nonce"
-
-    local max_retries=3
     for ((i = 1; i <= count; i++)); do
         local attempt=0
         local sent=false
         while [[ "$sent" == "false" && $attempt -lt $max_retries ]]; do
             if send_bridge_tx "$bridge_address" "$rpc_url" "$dest_chain_id" \
-                "$amount_wei" "$total_value_wei" "$direction_label" "$i" "$count" "$current_nonce"; then
+                "$amount_wei" "$total_value_wei" "$direction_label" "$i" "$count"; then
                 ((success_count++)) || true
                 sent=true
             else
                 ((attempt++)) || true
                 if [[ $attempt -lt $max_retries ]]; then
-                    # Brief pause to allow pending txs to be mined before refreshing nonce
-                    sleep 2
-                    current_nonce=$(cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url" --pending 2>/dev/null || cast nonce "$PUBLIC_KEY" --rpc-url "$rpc_url")
-                    log_info "Retrying with refreshed nonce: $current_nonce (attempt $((attempt+1))/$max_retries)"
+                    log_info "Retrying in ${retry_delay}s (attempt $((attempt+1))/$max_retries)..."
+                    sleep "$retry_delay"
                 fi
             fi
         done
         if [[ "$sent" == "false" ]]; then
             ((fail_count++)) || true
         fi
-        ((current_nonce++)) || true
     done
 
     echo
@@ -308,6 +297,7 @@ run_bridge_spam() {
 
     if [[ $fail_count -gt 0 ]]; then
         log_warning "$fail_count transactions failed for $direction_label"
+        return 1
     else
         log_success "All $direction_label transactions completed successfully"
     fi
@@ -417,6 +407,8 @@ main() {
     l1_rpc=$(echo "$l1_rpc" | sed 's/host\.docker\.internal/localhost/g')
     l2_rpc=$(echo "$l2_rpc" | sed 's/host\.docker\.internal/localhost/g')
 
+    log_info "Using deployer wallet: $PUBLIC_KEY"
+
     # Map direction to label
     local dir_label
     case "$dir_choice" in
@@ -429,19 +421,18 @@ main() {
     confirm_execution "$tx_count" "$dir_label" "$eth_amount"
 
     # Execute bridge spam
-    local total_success=0
-    local total_fail=0
+    local has_failures=false
 
     case "$dir_choice" in
         1)
             # L1 -> L2: call L1 bridge, dest = L2 chain
             run_bridge_spam "L1 → L2" "$SHASTA_BRIDGE" "$l1_rpc" "$L2_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count"
+                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
             ;;
         2)
             # L2 -> L1: call L2 bridge, dest = L1 chain
             run_bridge_spam "L2 → L1" "$L2_BRIDGE" "$l2_rpc" "$L1_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count"
+                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
             ;;
         3)
             # Both directions: send full count in each direction
@@ -449,11 +440,11 @@ main() {
 
             # L1 -> L2
             run_bridge_spam "L1 → L2" "$SHASTA_BRIDGE" "$l1_rpc" "$L2_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count"
+                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
 
             # L2 -> L1
             run_bridge_spam "L2 → L1" "$L2_BRIDGE" "$l2_rpc" "$L1_CHAIN_ID" \
-                "$amount_wei" "$total_value_wei" "$tx_count"
+                "$amount_wei" "$total_value_wei" "$tx_count" || has_failures=true
             ;;
     esac
 
@@ -464,7 +455,12 @@ main() {
     echo "╚══════════════════════════════════════════════════════════════╝"
     echo
 
-    log_success "Bridge transaction spamming complete!"
+    if [[ "$has_failures" == "true" ]]; then
+        log_error "Bridge transaction spamming finished with failures"
+        exit 1
+    else
+        log_success "Bridge transaction spamming complete!"
+    fi
 }
 
 # Run main function

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -228,7 +228,19 @@ validate_prerequisites() {
         log_error "Please install them first"
         return 1
     fi
-    
+
+    # Verify docker compose v2.1+ (required for --profile support)
+    local compose_version
+    compose_version=$(docker compose version --short 2>/dev/null || echo "0.0.0")
+    local compose_major compose_minor
+    compose_major=$(echo "$compose_version" | cut -d. -f1)
+    compose_minor=$(echo "$compose_version" | cut -d. -f2)
+    if [[ "$compose_major" -lt 2 ]] || [[ "$compose_major" -eq 2 && "$compose_minor" -lt 1 ]]; then
+        log_error "docker compose >= 2.1 required (found: $compose_version)"
+        return 1
+    fi
+    log_info "docker compose version: $compose_version"
+
     # Create required directories
     for dir in "$DEPLOYMENT_DIR" "$CONFIGS_DIR" "driver-data"; do
         if [[ ! -d "$dir" ]]; then
@@ -1912,7 +1924,7 @@ wait_for_l2_blocks() {
     l2_rpc=$(echo "$l2_rpc" | sed 's/host\.docker\.internal/localhost/g')
 
     local waited=0
-    local max_wait=384  # Entire epoch duration
+    local max_wait=600  # 10 minutes
     while [[ $waited -lt $max_wait ]]; do
         local block_number
         block_number=$(cast block-number --rpc-url "$l2_rpc" 2>/dev/null || echo "0")
@@ -1953,12 +1965,12 @@ deploy_l2() {
         # Start L2 deployer in detached mode, then wait for it to finish
         BROADCAST=true docker compose --profile l2-deployer up -d >"$temp_output" 2>&1 &
         local deploy_pid=$!
-
+        
         show_progress $deploy_pid "Deploying L2 contracts..."
-
+        
         wait $deploy_pid
         exit_status=$?
-
+        
         if [[ $exit_status -ne 0 ]]; then
             log_error "Failed to start L2 deployer container (exit code: $exit_status)"
             if [[ -f "$temp_output" ]]; then
@@ -1966,12 +1978,12 @@ deploy_l2() {
             fi
             return 1
         fi
-
+        
         # Wait for the deployer container to finish (up to 600s)
         # The deployer runs forge script --broadcast which needs L2 blocks to confirm txs
         log_info "Waiting for L2 deployer to complete..."
         local waited=0
-        local max_wait=600
+        local max_wait=${CI_L2_DEPLOYER_TIMEOUT:-600}
         while [[ $waited -lt $max_wait ]]; do
             # Check if the deployment artifact appeared on the host (most reliable signal)
             if [[ -f "$DEPLOYMENT_DIR/setup_l2.json" ]]; then
@@ -2005,7 +2017,7 @@ deploy_l2() {
             docker logs surge-l2-deployer 2>&1 | tail -20 >&2
             return 1
         fi
-
+        
         # Verify the deployment artifact was produced
         if [[ -f "$DEPLOYMENT_DIR/setup_l2.json" ]]; then
             log_success "L2 smart contracts deployed successfully"
@@ -2013,7 +2025,7 @@ deploy_l2() {
         else
             log_warning "L2 deployer exited 0 but setup_l2.json not found, continuing..."
         fi
-
+        
         return 0
     fi
 }
@@ -2583,7 +2595,7 @@ main() {
         # Deploy L1 contracts
         local mock_proof
         if [[ "$force" == "true" ]]; then
-            mock_proof=0  # default: mock prover
+            mock_proof=0
         else
             echo
             echo "╔══════════════════════════════════════════════════════════════╗"

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -1473,8 +1473,18 @@ extract_l1_deployment_results() {
     echo " BRIDGE: $SHASTA_BRIDGE "
     echo " SIGNAL_SERVICE: $SHASTA_SIGNAL_SERVICE "
     echo " PRECONF_WHITELIST: $SHASTA_PRECONF_WHITELIST "
+    echo " RISC0_VERIFIER: $SHASTA_RISC0_VERIFIER "
+    echo " SP1_VERIFIER: $SHASTA_SP1_VERIFIER "
+    echo " PROOF_VERIFIER_DUMMY: $SHASTA_PROOF_VERIFIER_DUMMY "
+    echo " SURGE_VERIFIER: $SHASTA_SURGE_VERIFIER "
     echo ">>>>>>"
     echo
+    if [[ -f "$L1_DEPLOYMENT_FILE" ]]; then
+        echo "=== deploy_l1.json ==="
+        cat "$L1_DEPLOYMENT_FILE"
+        echo ""
+        echo "=== end deploy_l1.json ==="
+    fi
 
     log_info "Updating .env with extracted values..."
 
@@ -1677,8 +1687,7 @@ deploy_provers() {
     local should_run_provers
     
     if [[ "$mock_proof" == "0" ]]; then
-        generate_prover_chain_spec
-        log_info "Skipping provers deployment...using mock prover"
+        log_info "Skipping provers deployment and chain spec (USE_DUMMY_VERIFIER=true)"
         return 0
     fi
 
@@ -2110,7 +2119,13 @@ start_l2_stack() {
     local compose_cmd="docker compose"
     local exit_status=0
     local temp_output="/tmp/surge_l2_stack_output_$$"
-    
+    # Skip raiko when using dummy verifier - no ZK proofs needed
+    local prover_profile="--profile prover"
+    if [[ "${USE_DUMMY_VERIFIER:-false}" == "true" ]]; then
+        log_info "USE_DUMMY_VERIFIER=true: skipping raiko (--profile prover)"
+        prover_profile=""
+    fi
+
     case "$stack_option" in
         1)
             log_info "Starting driver only"
@@ -2126,15 +2141,15 @@ start_l2_stack() {
             ;;
         4)
             log_info "Starting driver + proposer + prover (spammer deferred until after L2 deploy)"
-            $compose_cmd --profile catalyst --profile prover --profile blockscout up -d  >"$temp_output" 2>&1 &
+            $compose_cmd --profile catalyst $prover_profile --profile blockscout up -d  >"$temp_output" 2>&1 &
             ;;
         5)
             log_info "Starting all except spammer"
-            $compose_cmd --profile driver --profile catalyst --profile prover --profile blockscout up -d  >"$temp_output" 2>&1 &
+            $compose_cmd --profile driver --profile catalyst $prover_profile --profile blockscout up -d  >"$temp_output" 2>&1 &
             ;;
         *)
             log_info "Starting all components (spammer deferred until after L2 deploy)"
-            $compose_cmd --profile driver --profile catalyst --profile prover --profile blockscout up -d  >"$temp_output" 2>&1 &
+            $compose_cmd --profile driver --profile catalyst $prover_profile --profile blockscout up -d  >"$temp_output" 2>&1 &
             ;;
     esac
     

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -1937,9 +1937,28 @@ wait_for_l2_blocks() {
         if (( waited % 30 == 0 )); then
             log_info "Still waiting for L2 blocks... (${waited}s elapsed)"
         fi
+        # Dump container diagnostics periodically (every 120s) to aid debugging
+        if (( waited % 120 == 0 )); then
+            log_info "=== L2 container diagnostics (${waited}s elapsed) ==="
+            log_info "--- Container status ---"
+            docker compose ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || true
+            for svc in l2-nethermind-execution-client l2-taiko-consensus-client l2-catalyst-node; do
+                log_info "--- Last 15 lines from $svc ---"
+                docker logs --tail 15 "$svc" 2>&1 || true
+            done
+            log_info "=== End diagnostics ==="
+        fi
     done
 
     log_error "L2 did not start producing blocks within ${max_wait}s"
+    log_error "=== Final L2 container diagnostics ==="
+    log_error "--- Container status ---"
+    docker compose ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || true
+    for svc in l2-nethermind-execution-client l2-taiko-consensus-client l2-catalyst-node; do
+        log_error "--- Last 30 lines from $svc ---"
+        docker logs --tail 30 "$svc" 2>&1 || true
+    done
+    log_error "=== End diagnostics ==="
     return 1
 }
 
@@ -2702,6 +2721,10 @@ main() {
     
     if ! start_relayers "$relayers_choice" "$env_choice"; then
         log_warning "Relayer startup had issues, but continuing..."
+        log_warning "--- Relayer-related container status ---"
+        docker compose ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || true
+        docker compose -f docker-compose-relayer.yml ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || true
+        log_warning "--- End relayer diagnostics ---"
     fi
     
     # Step 5b: Start spammer now that L2 deploy is done (if stack option included it)

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -1942,10 +1942,11 @@ wait_for_l2_blocks() {
             log_info "=== L2 container diagnostics (${waited}s elapsed) ==="
             log_info "--- Container status ---"
             docker compose ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || true
-            for svc in l2-nethermind-execution-client l2-taiko-consensus-client l2-catalyst-node; do
+            while IFS= read -r svc; do
+                [[ -z "$svc" ]] && continue
                 log_info "--- Last 15 lines from $svc ---"
                 docker logs --tail 15 "$svc" 2>&1 || true
-            done
+            done < <(docker compose ps --format "{{.Name}}" 2>/dev/null)
             log_info "=== End diagnostics ==="
         fi
     done
@@ -1954,10 +1955,11 @@ wait_for_l2_blocks() {
     log_error "=== Final L2 container diagnostics ==="
     log_error "--- Container status ---"
     docker compose ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || true
-    for svc in l2-nethermind-execution-client l2-taiko-consensus-client l2-catalyst-node; do
+    while IFS= read -r svc; do
+        [[ -z "$svc" ]] && continue
         log_error "--- Last 30 lines from $svc ---"
         docker logs --tail 30 "$svc" 2>&1 || true
-    done
+    done < <(docker compose ps --format "{{.Name}}" 2>/dev/null)
     log_error "=== End diagnostics ==="
     return 1
 }

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -1127,6 +1127,12 @@ generate_prover_chain_spec() {
     local l1_beacon_docker="${L1_BEACON_HTTP_DOCKER:-http://host.docker.internal:33001}"
     local l2_rpc_docker="${L2_ENDPOINT_HTTP_DOCKER:-http://host.docker.internal:8547}"
 
+    # Resolve verifier addresses - use zero address as fallback when not deployed (dummy verifier mode)
+    local shasta_sp1_verifier="${SHASTA_SP1_VERIFIER:-}"
+    local shasta_risc0_verifier="${SHASTA_RISC0_VERIFIER:-}"
+    [[ -z "$shasta_sp1_verifier" || "$shasta_sp1_verifier" == "null" ]] && shasta_sp1_verifier="0x0000000000000000000000000000000000000000"
+    [[ -z "$shasta_risc0_verifier" || "$shasta_risc0_verifier" == "null" ]] && shasta_risc0_verifier="0x0000000000000000000000000000000000000000"
+
     # Generate chain spec list
     cat > "$CONFIGS_DIR/chain_spec_list_default.json" << EOF
 [
@@ -1188,8 +1194,8 @@ generate_prover_chain_spec() {
         "RISC0": "$PACAYA_RISC0_RETH_VERIFIER"
       },
       "SHASTA": {
-        "SP1": "$SHASTA_SP1_VERIFIER",
-        "RISC0": "$SHASTA_RISC0_VERIFIER"
+        "SP1": "$shasta_sp1_verifier",
+        "RISC0": "$shasta_risc0_verifier"
       }
     },
     "genesis_time": 0,
@@ -1687,7 +1693,8 @@ deploy_provers() {
     local should_run_provers
     
     if [[ "$mock_proof" == "0" ]]; then
-        log_info "Skipping provers deployment and chain spec (USE_DUMMY_VERIFIER=true)"
+        log_info "USE_DUMMY_VERIFIER=true: generating chain spec for raiko mock mode, skipping ZK verifier setup"
+        generate_prover_chain_spec
         return 0
     fi
 
@@ -2119,12 +2126,7 @@ start_l2_stack() {
     local compose_cmd="docker compose"
     local exit_status=0
     local temp_output="/tmp/surge_l2_stack_output_$$"
-    # Skip raiko when using dummy verifier - no ZK proofs needed
     local prover_profile="--profile prover"
-    if [[ "${USE_DUMMY_VERIFIER:-false}" == "true" ]]; then
-        log_info "USE_DUMMY_VERIFIER=true: skipping raiko (--profile prover)"
-        prover_profile=""
-    fi
 
     case "$stack_option" in
         1)

--- a/remove-surge-full.sh
+++ b/remove-surge-full.sh
@@ -528,11 +528,11 @@ prompt_component_selection() {
     echo "║  4. Persistent data directories                              ║" >&2
     echo "║  5. Configuration files                                      ║" >&2
     echo "║  6. Environment file (.env)                                  ║" >&2
-    echo "║ [default: Remove all except environment file]                ║" >&2
+    echo "║ [default: Remove L2 stack, keep L1 devnet]                    ║" >&2
     echo "╚══════════════════════════════════════════════════════════════╝" >&2
     echo >&2
-    read -p "Enter components to remove (1-6, comma-separated) [1,2,3,4,5]: " components
-    components=${components:-"1,2,3,4,5"}
+    read -p "Enter components to remove (1-6, comma-separated) [2,3,4,5]: " components
+    components=${components:-"2,3,4,5"}
     echo $components
 }
 
@@ -671,7 +671,13 @@ main() {
     # Get component selection if not specified
     local components_to_remove
     if [[ -z "${remove_l1_devnet:-}${remove_l2_stack:-}${remove_relayers:-}${remove_data:-}${remove_configs:-}${remove_env:-}" ]]; then
-        components_to_remove=$(prompt_component_selection)
+        if [[ "$force" == "true" ]]; then
+            # With --force and no component flags, use default (keep L1 devnet)
+            components_to_remove="2,3,4,5"
+            log_info "Using default: remove L2 stack, relayers, data, configs (keeping L1 devnet)"
+        else
+            components_to_remove=$(prompt_component_selection)
+        fi
     fi
     
     # Parse component selection

--- a/script/ci-e2e.sh
+++ b/script/ci-e2e.sh
@@ -98,13 +98,15 @@ kurtosis clean -a 2>/dev/null || true
 docker network create surge-network 2>/dev/null || true
 
 # --- CI overrides ---
-# Use dummy verifier in CI: skips ZK proof generation (raiko), avoids dependency on
-# SP1/RISC0 verifier setup which is not needed for e2e correctness testing.
+# Use dummy verifier in CI: avoids dependency on SP1/RISC0 ZK verifier contracts.
+# PROVER_DUMMY=true makes the prover submit dummy proofs (no ZK computation).
+# Raiko still starts for mock signing; chainspec uses zero addresses for null verifiers.
 log "Applying CI overrides to .env.devnet..."
 sed -i 's/^USE_DUMMY_VERIFIER=.*/USE_DUMMY_VERIFIER=true/' .env.devnet
 sed -i 's/^DEPLOY_RISC0_RETH_VERIFIER=.*/DEPLOY_RISC0_RETH_VERIFIER=false/' .env.devnet
 sed -i 's/^DEPLOY_SP1_RETH_VERIFIER=.*/DEPLOY_SP1_RETH_VERIFIER=false/' .env.devnet
 sed -i 's/^NUM_PROOFS_THRESHOLD=.*/NUM_PROOFS_THRESHOLD=0/' .env.devnet
+sed -i 's/^PROVER_DUMMY=.*/PROVER_DUMMY=true/' .env.devnet
 
 # --- Deploy ---
 log "Deploying full stack..."

--- a/script/ci-e2e.sh
+++ b/script/ci-e2e.sh
@@ -98,15 +98,15 @@ kurtosis clean -a 2>/dev/null || true
 docker network create surge-network 2>/dev/null || true
 
 # --- CI overrides ---
-# Use dummy verifier in CI: avoids dependency on SP1/RISC0 ZK verifier contracts.
-# PROVER_DUMMY=true makes the prover submit dummy proofs (no ZK computation).
-# Raiko still starts for mock signing; chainspec uses zero addresses for null verifiers.
+# Use dummy verifier in CI: deploys ProofVerifierDummy that accepts ECDSA signatures.
+# Raiko runs in mock mode (ZK=true, MOCK_KEY=PRIVATE_KEY) and signs commitments with
+# PRIVATE_KEY. ProofVerifierDummy accepts these signatures since DUMMY_VERIFIER_SIGNER=PUBLIC_KEY.
+# DEPLOY_RISC0_RETH_VERIFIER and DEPLOY_SP1_RETH_VERIFIER must stay true so ProofVerifierDummy
+# gets registered in SurgeVerifier for both bit flags (otherwise Surge_InvalidProofBitFlag).
+# NUM_PROOFS_THRESHOLD=0 so finalization requires 0 proof types (any valid proofs suffice).
 log "Applying CI overrides to .env.devnet..."
 sed -i 's/^USE_DUMMY_VERIFIER=.*/USE_DUMMY_VERIFIER=true/' .env.devnet
-sed -i 's/^DEPLOY_RISC0_RETH_VERIFIER=.*/DEPLOY_RISC0_RETH_VERIFIER=false/' .env.devnet
-sed -i 's/^DEPLOY_SP1_RETH_VERIFIER=.*/DEPLOY_SP1_RETH_VERIFIER=false/' .env.devnet
 sed -i 's/^NUM_PROOFS_THRESHOLD=.*/NUM_PROOFS_THRESHOLD=0/' .env.devnet
-sed -i 's/^PROVER_DUMMY=.*/PROVER_DUMMY=true/' .env.devnet
 
 # --- Deploy ---
 log "Deploying full stack..."

--- a/script/ci-e2e.sh
+++ b/script/ci-e2e.sh
@@ -9,11 +9,28 @@ NO_CLEANUP="${NO_CLEANUP:-false}"
 
 log() { echo "[CI-E2E] $(date '+%H:%M:%S') $1"; }
 
+dump_failure_logs() {
+    log "=== Collecting container logs before teardown ==="
+    docker ps -a --format "{{.Names}}\t{{.Status}}" 2>/dev/null || true
+    while IFS= read -r container; do
+        [[ -z "$container" ]] && continue
+        echo ""
+        echo "--- $container (last 100 lines) ---"
+        docker logs --tail 100 "$container" 2>&1 || true
+    done < <(docker ps --format "{{.Names}}" 2>/dev/null)
+    echo ""
+    log "=== End container logs ==="
+}
+
 cleanup() {
     local exit_code=$?
     if [[ "$NO_CLEANUP" == "true" && $exit_code -ne 0 ]]; then
         log "Skipping teardown (NO_CLEANUP=true, exit_code=$exit_code)"
         exit $exit_code
+    fi
+
+    if [[ $exit_code -ne 0 ]]; then
+        dump_failure_logs
     fi
 
     log "Teardown starting (exit_code=$exit_code)..."

--- a/script/ci-e2e.sh
+++ b/script/ci-e2e.sh
@@ -98,15 +98,15 @@ kurtosis clean -a 2>/dev/null || true
 docker network create surge-network 2>/dev/null || true
 
 # --- CI overrides ---
-# Use dummy verifier in CI: deploys ProofVerifierDummy that accepts ECDSA signatures.
-# Raiko runs in mock mode (ZK=true, MOCK_KEY=PRIVATE_KEY) and signs commitments with
-# PRIVATE_KEY. ProofVerifierDummy accepts these signatures since DUMMY_VERIFIER_SIGNER=PUBLIC_KEY.
-# DEPLOY_RISC0_RETH_VERIFIER and DEPLOY_SP1_RETH_VERIFIER must stay true so ProofVerifierDummy
-# gets registered in SurgeVerifier for both bit flags (otherwise Surge_InvalidProofBitFlag).
-# NUM_PROOFS_THRESHOLD=0 so finalization requires 0 proof types (any valid proofs suffice).
+# Use dummy verifier in CI: avoids dependency on SP1/RISC0 ZK verifier contracts.
+# PROVER_DUMMY=true makes the prover submit dummy proofs (no ZK computation).
+# Raiko still starts for mock signing; chainspec uses zero addresses for null verifiers.
 log "Applying CI overrides to .env.devnet..."
 sed -i 's/^USE_DUMMY_VERIFIER=.*/USE_DUMMY_VERIFIER=true/' .env.devnet
+sed -i 's/^DEPLOY_RISC0_RETH_VERIFIER=.*/DEPLOY_RISC0_RETH_VERIFIER=false/' .env.devnet
+sed -i 's/^DEPLOY_SP1_RETH_VERIFIER=.*/DEPLOY_SP1_RETH_VERIFIER=false/' .env.devnet
 sed -i 's/^NUM_PROOFS_THRESHOLD=.*/NUM_PROOFS_THRESHOLD=0/' .env.devnet
+sed -i 's/^PROVER_DUMMY=.*/PROVER_DUMMY=true/' .env.devnet
 
 # --- Deploy ---
 log "Deploying full stack..."

--- a/script/ci-e2e.sh
+++ b/script/ci-e2e.sh
@@ -104,6 +104,7 @@ log "Applying CI overrides to .env.devnet..."
 sed -i 's/^USE_DUMMY_VERIFIER=.*/USE_DUMMY_VERIFIER=true/' .env.devnet
 sed -i 's/^DEPLOY_RISC0_RETH_VERIFIER=.*/DEPLOY_RISC0_RETH_VERIFIER=false/' .env.devnet
 sed -i 's/^DEPLOY_SP1_RETH_VERIFIER=.*/DEPLOY_SP1_RETH_VERIFIER=false/' .env.devnet
+sed -i 's/^NUM_PROOFS_THRESHOLD=.*/NUM_PROOFS_THRESHOLD=0/' .env.devnet
 
 # --- Deploy ---
 log "Deploying full stack..."

--- a/script/ci-e2e.sh
+++ b/script/ci-e2e.sh
@@ -97,6 +97,14 @@ kurtosis clean -a 2>/dev/null || true
 # Create fresh network
 docker network create surge-network 2>/dev/null || true
 
+# --- CI overrides ---
+# Use dummy verifier in CI: skips ZK proof generation (raiko), avoids dependency on
+# SP1/RISC0 verifier setup which is not needed for e2e correctness testing.
+log "Applying CI overrides to .env.devnet..."
+sed -i 's/^USE_DUMMY_VERIFIER=.*/USE_DUMMY_VERIFIER=true/' .env.devnet
+sed -i 's/^DEPLOY_RISC0_RETH_VERIFIER=.*/DEPLOY_RISC0_RETH_VERIFIER=false/' .env.devnet
+sed -i 's/^DEPLOY_SP1_RETH_VERIFIER=.*/DEPLOY_SP1_RETH_VERIFIER=false/' .env.devnet
+
 # --- Deploy ---
 log "Deploying full stack..."
 ./deploy-surge-full.sh \

--- a/script/ci-e2e.sh
+++ b/script/ci-e2e.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+NO_CLEANUP="${NO_CLEANUP:-false}"
+
+log() { echo "[CI-E2E] $(date '+%H:%M:%S') $1"; }
+
+cleanup() {
+    local exit_code=$?
+    if [[ "$NO_CLEANUP" == "true" && $exit_code -ne 0 ]]; then
+        log "Skipping teardown (NO_CLEANUP=true, exit_code=$exit_code)"
+        exit $exit_code
+    fi
+
+    log "Teardown starting (exit_code=$exit_code)..."
+
+    ./remove-surge-full.sh \
+        --remove-l1-devnet true \
+        --remove-l2-stack true \
+        --remove-relayers true \
+        --remove-data true \
+        --remove-configs true \
+        --remove-env true \
+        --mode debug \
+        --force || true
+
+    docker network rm surge-network 2>/dev/null || true
+
+    if command -v kurtosis &>/dev/null; then
+        kurtosis enclave rm surge-devnet --force 2>/dev/null || true
+        kurtosis clean -a 2>/dev/null || true
+    fi
+
+    docker system prune -af --volumes 2>/dev/null || true
+
+    log "Teardown complete."
+    exit $exit_code
+}
+trap cleanup EXIT
+
+# --- Pre-flight ---
+log "Pre-flight checks..."
+for cmd in docker git jq curl bc cast kurtosis; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Missing required tool: $cmd" >&2
+        exit 1
+    fi
+done
+
+# Verify docker compose v2.1+ (required for --profile support)
+compose_version=$(docker compose version --short 2>/dev/null || echo "0.0.0")
+compose_major=$(echo "$compose_version" | cut -d. -f1)
+compose_minor=$(echo "$compose_version" | cut -d. -f2)
+if [[ "$compose_major" -lt 2 ]] || [[ "$compose_major" -eq 2 && "$compose_minor" -lt 1 ]]; then
+    echo "docker compose >= 2.1 required (found: $compose_version)" >&2
+    exit 1
+fi
+log "docker compose version: $compose_version"
+
+# Clean any leftover state from previous runs
+log "Cleaning leftover state..."
+./remove-surge-full.sh \
+    --remove-l1-devnet true \
+    --remove-l2-stack true \
+    --remove-relayers true \
+    --remove-data true \
+    --remove-configs true \
+    --remove-env true \
+    --mode silence \
+    --force 2>/dev/null || true
+
+docker network rm surge-network 2>/dev/null || true
+kurtosis enclave rm surge-devnet --force 2>/dev/null || true
+kurtosis clean -a 2>/dev/null || true
+
+# Create fresh network
+docker network create surge-network 2>/dev/null || true
+
+# --- Deploy ---
+log "Deploying full stack..."
+./deploy-surge-full.sh \
+    --environment devnet \
+    --deploy-devnet true \
+    --deployment local \
+    --start-relayers true \
+    --force
+
+log "Deploy completed successfully."
+
+# --- Health checks ---
+log "Running health checks..."
+"$SCRIPT_DIR/ci-health-check.sh"
+
+log "E2E pipeline passed."

--- a/script/ci-health-check.sh
+++ b/script/ci-health-check.sh
@@ -16,6 +16,18 @@ if [[ -f "$PROJECT_DIR/.env" ]]; then
 fi
 
 log() { echo "[E2E] $(date '+%H:%M:%S') $1"; }
+
+dump_bridge_logs() {
+    echo "[E2E] === All container logs ===" >&2
+    docker ps -a --format "{{.Names}}\t{{.Status}}" 2>/dev/null >&2 || true
+    while IFS= read -r container; do
+        [[ -z "$container" ]] && continue
+        echo "[E2E] --- $container (last 50 lines) ---" >&2
+        docker logs --tail 50 "$container" 2>&1 >&2 || true
+    done < <(docker ps --format "{{.Names}}" 2>/dev/null)
+    echo "[E2E] === End container logs ===" >&2
+}
+
 fail() { echo "[E2E] FAIL: $1" >&2; exit 1; }
 
 check_rpc() {
@@ -191,6 +203,7 @@ if [[ -n "${SHASTA_BRIDGE:-}" && -n "${PUBLIC_KEY:-}" && -n "${PRIVATE_KEY:-}" &
     done
 
     if [[ "$delivered" != "true" ]]; then
+        dump_bridge_logs
         fail "L1->L2 bridge delivery not confirmed within ${delivery_timeout}s (recipient balance still 0)"
     fi
 else
@@ -270,6 +283,7 @@ if [[ -n "${L2_BRIDGE:-}" && -n "${PUBLIC_KEY:-}" && -n "${PRIVATE_KEY:-}" && -n
     done
 
     if [[ "$l2l1_delivered" != "true" ]]; then
+        dump_bridge_logs
         fail "L2->L1 bridge delivery not confirmed within ${l2l1_delivery_timeout}s (recipient balance still 0)"
     fi
 else

--- a/script/ci-health-check.sh
+++ b/script/ci-health-check.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+set -euo pipefail
+
+L1_RPC="${L1_RPC:-http://localhost:32003}"
+L2_RPC="${L2_RPC:-http://localhost:8547}"
+MAX_RETRIES="${CI_HEALTH_MAX_RETRIES:-30}"
+RETRY_INTERVAL="${CI_HEALTH_RETRY_INTERVAL:-10}"
+
+# Source .env for deployment variables (contract addresses, chain config)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+fi
+
+log() { echo "[E2E] $(date '+%H:%M:%S') $1"; }
+fail() { echo "[E2E] FAIL: $1" >&2; exit 1; }
+
+check_rpc() {
+    local name="$1" url="$2"
+    local result
+    result=$(curl -sf -X POST "$url" \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' 2>/dev/null) || return 1
+    echo "$result" | jq -e '.result' >/dev/null 2>&1 || return 1
+    local block_hex
+    block_hex=$(echo "$result" | jq -r '.result')
+    local block_num=$((block_hex))
+    log "$name block number: $block_num"
+    return 0
+}
+
+wait_for_l2_blocks() {
+    local attempt=0
+    log "Waiting for L2 to produce blocks..."
+    while [[ $attempt -lt $MAX_RETRIES ]]; do
+        if check_rpc "L2" "$L2_RPC"; then
+            local result
+            result=$(curl -sf -X POST "$L2_RPC" \
+                -H "Content-Type: application/json" \
+                -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}')
+            local block_hex
+            block_hex=$(echo "$result" | jq -r '.result')
+            local block_num=$((block_hex))
+            if [[ $block_num -gt 0 ]]; then
+                log "L2 is producing blocks (block $block_num)."
+                return 0
+            fi
+        fi
+        attempt=$((attempt + 1))
+        log "Attempt $attempt/$MAX_RETRIES - L2 not ready yet, waiting ${RETRY_INTERVAL}s..."
+        sleep "$RETRY_INTERVAL"
+    done
+    fail "L2 did not produce blocks within $((MAX_RETRIES * RETRY_INTERVAL))s"
+}
+
+# Step 1: Check L1
+log "Checking L1 RPC ($L1_RPC)..."
+check_rpc "L1" "$L1_RPC" || fail "L1 RPC not responding"
+
+# Step 2: Check L2 blocks
+log "Checking L2 RPC ($L2_RPC)..."
+wait_for_l2_blocks
+
+# Step 3: Check critical containers
+log "Checking container health..."
+for container in l2-nethermind-execution-client l2-taiko-consensus-client l2-catalyst-node; do
+    status=$(docker inspect "$container" --format '{{.State.Status}}' 2>/dev/null || echo "not found")
+    if [[ "$status" != "running" ]]; then
+        fail "Container $container is not running (status: $status)"
+    fi
+    log "Container $container: running"
+done
+
+# Step 4: Verify L2 chain ID
+log "Verifying L2 chain ID..."
+chain_result=$(curl -sf -X POST "$L2_RPC" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}')
+chain_id_hex=$(echo "$chain_result" | jq -r '.result')
+chain_id=$((chain_id_hex))
+expected_chain_id="${L2_CHAIN_ID:-}"
+if [[ -n "$expected_chain_id" && "$chain_id" != "$expected_chain_id" ]]; then
+    fail "L2 chain ID mismatch: got $chain_id, expected $expected_chain_id"
+fi
+log "L2 chain ID: $chain_id (expected: ${expected_chain_id:-not set})"
+
+# Step 5: Verify deployment artifacts
+log "Checking deployment artifacts..."
+for artifact in deployment/deploy_l1.json deployment/deploy_l1_pacaya.json deployment/surge_genesis.json deployment/surge_chainspec.json; do
+    if [[ ! -f "$artifact" ]]; then
+        fail "Missing deployment artifact: $artifact"
+    fi
+    log "Artifact $artifact: present"
+done
+
+# Step 6: Verify Shasta fork activation
+log "Checking Shasta fork activation..."
+if [[ -n "${SHASTA_SURGE_INBOX:-}" && -n "${L1_RPC:-}" ]]; then
+    activation_ts=$(cast call "$SHASTA_SURGE_INBOX" "activationTimestamp()(uint48)" --rpc-url "$L1_RPC" 2>/dev/null || echo "")
+    if [[ -z "$activation_ts" || "$activation_ts" == "0" ]]; then
+        fail "Shasta fork not activated (activationTimestamp is 0 or empty on SurgeInbox $SHASTA_SURGE_INBOX)"
+    fi
+    log "Shasta fork activated at timestamp: $activation_ts"
+else
+    log "Skipping fork activation check (SHASTA_SURGE_INBOX or L1_RPC not set)"
+fi
+
+# Step 7: Check relayer containers
+log "Checking relayer containers..."
+for container in relayer-l1-processor relayer-l1-indexer relayer-l1-api relayer-l2-processor relayer-l2-indexer relayer-l2-api; do
+    status=$(docker inspect "$container" --format '{{.State.Status}}' 2>/dev/null || echo "not found")
+    if [[ "$status" == "running" ]]; then
+        log "Container $container: running"
+    else
+        log "Container $container: $status (non-critical)"
+    fi
+done
+
+# Step 8: L1->L2 bridge delivery verification
+log "Verifying L1->L2 bridge delivery..."
+if [[ -n "${SHASTA_BRIDGE:-}" && -n "${PUBLIC_KEY:-}" && -n "${PRIVATE_KEY:-}" && -n "${L2_CHAIN_ID:-}" ]]; then
+    BRIDGE_AMOUNT_WEI="10000000000000000"
+    BRIDGE_FEE_WEI="10000000000000000"
+    BRIDGE_GAS_LIMIT="1000000"
+    BRIDGE_TOTAL_WEI=$(echo "$BRIDGE_AMOUNT_WEI + $BRIDGE_FEE_WEI" | bc)
+    BRIDGE_ZERO="0x0000000000000000000000000000000000000000"
+
+    # Use a fresh recipient address so balance check is not affected by other
+    # activity on the deployer key (relayer, prover, etc.)
+    l2_recipient=$(cast wallet new --json 2>/dev/null | jq -r '.[0].address')
+    log "L1->L2 recipient: $l2_recipient"
+
+    # Debug: log sender and recipient balances before submission
+    sender_l1_bal=$(cast balance "$PUBLIC_KEY" --rpc-url "$L1_RPC" 2>/dev/null || echo "N/A")
+    recipient_l2_bal=$(cast balance "$l2_recipient" --rpc-url "$L2_RPC" 2>/dev/null || echo "N/A")
+    log "Before L1->L2 bridge: sender L1 balance=$sender_l1_bal wei, recipient L2 balance=$recipient_l2_bal wei"
+
+    # Send L1->L2 bridge tx (with retries for nonce races)
+    log "Sending L1->L2 bridge tx (0.01 ETH) to $l2_recipient..."
+    bridge_sent=false
+    for attempt in 1 2 3 4 5; do
+        if cast send "$SHASTA_BRIDGE" \
+            "sendMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes))" \
+            "(0,$BRIDGE_FEE_WEI,$BRIDGE_GAS_LIMIT,$BRIDGE_ZERO,0,$l2_recipient,$L2_CHAIN_ID,$l2_recipient,$l2_recipient,$BRIDGE_AMOUNT_WEI,0x)" \
+            --value "$BRIDGE_TOTAL_WEI" \
+            --rpc-url "$L1_RPC" \
+            --private-key "$PRIVATE_KEY"; then
+            bridge_sent=true
+            break
+        fi
+        log "L1->L2 bridge tx attempt $attempt failed, retrying in 5s..."
+        sleep 5
+    done
+    if [[ "$bridge_sent" != "true" ]]; then
+        fail "L1->L2 bridge delivery tx failed to submit after 5 attempts"
+    fi
+    log "Bridge tx submitted, waiting for delivery on L2..."
+
+    # Poll fresh recipient L2 balance until it becomes > 0
+    delivery_timeout="${CI_BRIDGE_DELIVERY_TIMEOUT:-1200}"
+    delivery_interval=5
+    delivery_elapsed=0
+    delivered=false
+
+    while [[ $delivery_elapsed -lt $delivery_timeout ]]; do
+        sleep "$delivery_interval"
+        delivery_elapsed=$((delivery_elapsed + delivery_interval))
+        l2_balance=$(cast balance "$l2_recipient" --rpc-url "$L2_RPC" 2>/dev/null || echo "")
+
+        # Skip if RPC unavailable
+        if [[ -z "$l2_balance" ]]; then
+            log "Waiting for L1->L2 delivery... ${delivery_elapsed}/${delivery_timeout}s (L2 RPC unavailable)"
+            continue
+        fi
+
+        if [[ "$l2_balance" != "0" ]]; then
+            log "L1->L2 bridge delivered after ${delivery_elapsed}s (recipient balance: $l2_balance wei)"
+            delivered=true
+            break
+        fi
+        if (( delivery_elapsed % 60 == 0 )); then
+            sender_l1_now=$(cast balance "$PUBLIC_KEY" --rpc-url "$L1_RPC" 2>/dev/null || echo "N/A")
+            recipient_l2_now=$(cast balance "$l2_recipient" --rpc-url "$L2_RPC" 2>/dev/null || echo "N/A")
+            log "Waiting for L1->L2 delivery... ${delivery_elapsed}/${delivery_timeout}s (sender L1 bal=$sender_l1_now, recipient L2 bal=$recipient_l2_now)"
+        else
+            log "Waiting for L1->L2 delivery... ${delivery_elapsed}/${delivery_timeout}s"
+        fi
+    done
+
+    if [[ "$delivered" != "true" ]]; then
+        fail "L1->L2 bridge delivery not confirmed within ${delivery_timeout}s (recipient balance still 0)"
+    fi
+else
+    log "Skipping L1->L2 delivery check (missing SHASTA_BRIDGE, PUBLIC_KEY, PRIVATE_KEY, or L2_CHAIN_ID)"
+fi
+
+# Step 9: L2->L1 bridge delivery verification
+log "Verifying L2->L1 bridge delivery..."
+if [[ -n "${L2_BRIDGE:-}" && -n "${PUBLIC_KEY:-}" && -n "${PRIVATE_KEY:-}" && -n "${L1_CHAIN_ID:-}" ]]; then
+    L2L1_BRIDGE_AMOUNT_WEI="10000000000000000"
+    L2L1_BRIDGE_FEE_WEI="10000000000000000"
+    L2L1_BRIDGE_GAS_LIMIT="1000000"
+    L2L1_BRIDGE_TOTAL_WEI=$(echo "$L2L1_BRIDGE_AMOUNT_WEI + $L2L1_BRIDGE_FEE_WEI" | bc)
+    L2L1_BRIDGE_ZERO="0x0000000000000000000000000000000000000000"
+
+    # Use a fresh recipient address so balance check is not affected by other
+    # activity on the deployer key (prover gas spending, etc.)
+    l1_recipient=$(cast wallet new --json 2>/dev/null | jq -r '.[0].address')
+    log "L2->L1 recipient: $l1_recipient"
+
+    # Debug: log sender and recipient balances before submission
+    sender_l2_bal=$(cast balance "$PUBLIC_KEY" --rpc-url "$L2_RPC" 2>/dev/null || echo "N/A")
+    recipient_l1_bal=$(cast balance "$l1_recipient" --rpc-url "$L1_RPC" 2>/dev/null || echo "N/A")
+    log "Before L2->L1 bridge: sender L2 balance=$sender_l2_bal wei, recipient L1 balance=$recipient_l1_bal wei"
+
+    # Send L2->L1 bridge tx (with retries for nonce races)
+    log "Sending L2->L1 bridge tx (0.01 ETH) to $l1_recipient..."
+    l2l1_bridge_sent=false
+    for attempt in 1 2 3 4 5; do
+        if cast send "$L2_BRIDGE" \
+            "sendMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes))" \
+            "(0,$L2L1_BRIDGE_FEE_WEI,$L2L1_BRIDGE_GAS_LIMIT,$L2L1_BRIDGE_ZERO,0,$l1_recipient,$L1_CHAIN_ID,$l1_recipient,$l1_recipient,$L2L1_BRIDGE_AMOUNT_WEI,0x)" \
+            --value "$L2L1_BRIDGE_TOTAL_WEI" \
+            --rpc-url "$L2_RPC" \
+            --private-key "$PRIVATE_KEY"; then
+            l2l1_bridge_sent=true
+            break
+        fi
+        log "L2->L1 bridge tx attempt $attempt failed, retrying in 5s..."
+        sleep 5
+    done
+    if [[ "$l2l1_bridge_sent" != "true" ]]; then
+        fail "L2->L1 bridge delivery tx failed to submit after 5 attempts"
+    fi
+    log "L2->L1 bridge tx submitted, waiting for delivery on L1..."
+
+    # Poll fresh recipient L1 balance until it becomes > 0
+    l2l1_delivery_timeout="${CI_BRIDGE_DELIVERY_TIMEOUT:-1200}"
+    l2l1_delivery_interval=5
+    l2l1_delivery_elapsed=0
+    l2l1_delivered=false
+
+    while [[ $l2l1_delivery_elapsed -lt $l2l1_delivery_timeout ]]; do
+        sleep "$l2l1_delivery_interval"
+        l2l1_delivery_elapsed=$((l2l1_delivery_elapsed + l2l1_delivery_interval))
+        l1_balance=$(cast balance "$l1_recipient" --rpc-url "$L1_RPC" 2>/dev/null || echo "")
+
+        # Skip if RPC unavailable
+        if [[ -z "$l1_balance" ]]; then
+            log "Waiting for L2->L1 delivery... ${l2l1_delivery_elapsed}/${l2l1_delivery_timeout}s (L1 RPC unavailable)"
+            continue
+        fi
+
+        if [[ "$l1_balance" != "0" ]]; then
+            log "L2->L1 bridge delivered after ${l2l1_delivery_elapsed}s (recipient balance: $l1_balance wei)"
+            l2l1_delivered=true
+            break
+        fi
+        # Debug: log sender and recipient balances every 60s
+        if (( l2l1_delivery_elapsed % 60 == 0 )); then
+            sender_l2_now=$(cast balance "$PUBLIC_KEY" --rpc-url "$L2_RPC" 2>/dev/null || echo "N/A")
+            recipient_l1_now=$(cast balance "$l1_recipient" --rpc-url "$L1_RPC" 2>/dev/null || echo "N/A")
+            log "Waiting for L2->L1 delivery... ${l2l1_delivery_elapsed}/${l2l1_delivery_timeout}s (sender L2 bal=$sender_l2_now, recipient L1 bal=$recipient_l1_now)"
+        else
+            log "Waiting for L2->L1 delivery... ${l2l1_delivery_elapsed}/${l2l1_delivery_timeout}s"
+        fi
+    done
+
+    if [[ "$l2l1_delivered" != "true" ]]; then
+        fail "L2->L1 bridge delivery not confirmed within ${l2l1_delivery_timeout}s (recipient balance still 0)"
+    fi
+else
+    log "Skipping L2->L1 delivery check (missing L2_BRIDGE, PUBLIC_KEY, PRIVATE_KEY, or L1_CHAIN_ID)"
+fi
+
+log "All health checks passed."


### PR DESCRIPTION
- cleanup
- provision/re-use existing L1 devnet
- adjust updated env vars
- keep devnet L1 on default removal
- e2e bridging tests


L2->L1 bridge in e2e tests WORKS ONLY WITH
`NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-d6befe8`
and doesn't work with `nethermind:master` as of Mar-2026