### PR TITLE
Integrate L1STATICCALL into devnet script

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -1,4 +1,8 @@
 ############################### IMAGES #####################################
+# Only services that may be overridden with a locally-built image (nethermind-local,
+# raiko-zk) carry a `<SERVICE>_PULL_POLICY` override. `TAIKO_CLIENT_IMAGE` and
+# `CATALYST_IMAGE` are pinned to published tags and use docker-compose's default pull
+# policy; extend the `<SERVICE>_PULL_POLICY` pattern here if that ever changes.
 PACAYA_PROTOCOL_IMAGE=nethermind/catalyst-taiko-protocol:taiko-alethia-protocol-v2.3.1-new
 PROTOCOL_IMAGE=nethermind/surge-protocol:sha-b85d39a
 NETHERMIND_CLIENT_IMAGE=nethermind-local:latest

--- a/.env.devnet
+++ b/.env.devnet
@@ -1,10 +1,12 @@
 ############################### IMAGES #####################################
 PACAYA_PROTOCOL_IMAGE=nethermind/catalyst-taiko-protocol:taiko-alethia-protocol-v2.3.1-new
 PROTOCOL_IMAGE=nethermind/surge-protocol:sha-b85d39a
-NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-334488b
+NETHERMIND_CLIENT_IMAGE=nethermind-local:latest
+NETHERMIND_PULL_POLICY=never
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:surge-shasta-0933c0f9
 CATALYST_IMAGE=nethermind/catalyst-node:v1.30.0
-RAIKO_IMAGE=nethermind/surge-raiko-zk:sha-2c34626
+RAIKO_IMAGE=raiko-zk:latest
+RAIKO_PULL_POLICY=never
 
 ############################### DEFAULT #####################################
 CHAINSPEC_PATH_ON_HOST=./deployment/surge_chainspec.json

--- a/.env.devnet
+++ b/.env.devnet
@@ -1,16 +1,21 @@
 ############################### IMAGES #####################################
-# Only services that may be overridden with a locally-built image (nethermind-local,
-# raiko-zk) carry a `<SERVICE>_PULL_POLICY` override. `TAIKO_CLIENT_IMAGE` and
-# `CATALYST_IMAGE` are pinned to published tags and use docker-compose's default pull
-# policy; extend the `<SERVICE>_PULL_POLICY` pattern here if that ever changes.
+# All four service images are pinned to published Docker Hub tags. Two of them
+# (NETHERMIND_CLIENT_IMAGE and RAIKO_IMAGE) are CI-built from feature branches via
+# raiko-client--docker-build.yml / publish-docker.yml; the other two are upstream
+# release tags. No `<SERVICE>_PULL_POLICY` overrides — docker-compose's default
+# (pull-if-missing) is correct for all four. Add a `_PULL_POLICY=never` override
+# only when reverting to a *locally-built* image (e.g. for unmerged debug builds).
 PACAYA_PROTOCOL_IMAGE=nethermind/catalyst-taiko-protocol:taiko-alethia-protocol-v2.3.1-new
 PROTOCOL_IMAGE=nethermind/surge-protocol:sha-b85d39a
-NETHERMIND_CLIENT_IMAGE=nethermind-local:latest
-NETHERMIND_PULL_POLICY=never
+# CI-built from jmadibekov/l1-precompiles-block-range-validation @ a97178a317 via
+# .github/workflows/publish-docker.yml (run 25009463978).
+NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:l1staticcall
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:surge-shasta-0933c0f9
 CATALYST_IMAGE=nethermind/catalyst-node:v1.30.0
-RAIKO_IMAGE=raiko-zk:latest
-RAIKO_PULL_POLICY=never
+# CI-built from jmadibekov/l1staticcall @ 4ace21b5 via
+# .github/workflows/raiko-client--docker-build.yml (run 25009459403).
+# workflow_dispatch only produces sha-* / branch-slug / latest tags, not pr-*.
+RAIKO_IMAGE=nethermind/surge-raiko-zk:sha-4ace21b
 
 ############################### DEFAULT #####################################
 CHAINSPEC_PATH_ON_HOST=./deployment/surge_chainspec.json

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,6 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@4e5d8b13ca281a6d163cdb287d8917b216e00d6f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 .DS_Store
 .vscode/
 .cursorignore
+
+*.backup

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@
 .vscode/
 .cursorignore
 
-*.backup
+# Rotating backups of deploy-generated artifacts (chainspecs, chain-spec-list JSON).
+/deployment/*.backup
+/configs/*.backup

--- a/configs/network_params.yaml
+++ b/configs/network_params.yaml
@@ -1,7 +1,7 @@
 participants:
 # EL
   - el_type: nethermind
-    el_image: nethermindeth/nethermind:master-d6befe8
+    el_image: nethermind-local:latest
     el_log_level: ""
     el_extra_env_vars: {}
     el_extra_labels: {}

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -1148,7 +1148,7 @@ generate_prover_chain_spec() {
   {
     "name": "surge_dev",
     "chain_id": $L2_CHAIN_ID,
-    "max_spec_id": "PACAYA",
+    "max_spec_id": "SHASTA",
     "hard_forks": {
         "ONTAKE": {
             "Block": 1
@@ -1540,7 +1540,7 @@ generate_l2_genesis() {
 
     update_env_var "$ENV_FILE" "SHASTA_TIMESTAMP" "$HEX_TIMESTAMP"
 
-    cat "$SURGE_GENESIS_FILE" | jq --arg hex_timestamp "$HEX_TIMESTAMP" '. * {difficulty: 0, config: {taiko: true, londonBlock: 0, ontakeBlock: 0, pacayaBlock: 1, shastaTimestamp: $hex_timestamp, useSurgeGasPriceOracle: true, feeCollector: "0x0000000000000000000000000000000000000000", shanghaiTime: 0}} | del(.config.clique)' | jq --from-file <(curl -s https://raw.githubusercontent.com/NethermindEth/core-scripts/refs/heads/main/gen2spec/gen2spec.jq) | jq --arg hex_timestamp "$HEX_TIMESTAMP" '.engine.Taiko.shastaTimestamp = $hex_timestamp' | jq '.params.rip7728TransitionTimestamp = "0x0"' > "$DEPLOYMENT_DIR/surge_chainspec.json"
+    cat "$SURGE_GENESIS_FILE" | jq --arg hex_timestamp "$HEX_TIMESTAMP" '. * {difficulty: 0, config: {taiko: true, londonBlock: 0, ontakeBlock: 0, pacayaBlock: 1, shastaTimestamp: $hex_timestamp, useSurgeGasPriceOracle: true, feeCollector: "0x0000000000000000000000000000000000000000", shanghaiTime: 0}} | del(.config.clique)' | jq --from-file <(curl -s https://raw.githubusercontent.com/NethermindEth/core-scripts/refs/heads/main/gen2spec/gen2spec.jq) | jq --arg hex_timestamp "$HEX_TIMESTAMP" '.engine.Taiko.shastaTimestamp = $hex_timestamp' | jq '.engine.Taiko.rip7728TransitionTimestamp = "0x0"' | jq '.engine.Taiko.l1StaticCallTransitionTimestamp = "0x0"' > "$DEPLOYMENT_DIR/surge_chainspec.json"
     
     echo
     echo "╔══════════════════════════════════════════════════════════════╗"
@@ -2708,7 +2708,9 @@ main() {
     fi
     
     # Step 5b: Start spammer now that L2 deploy is done (if stack option included it)
-    if [[ "$stack_choice" == "3" || "$stack_choice" == "4" || "$stack_choice" == "6" || -z "$stack_choice" ]]; then
+    # DISABLED for L1STATICCALL e2e — spammer uses our test PRIVATE_KEY and its txs
+    # land in early L2 blocks with nonces that confuse raiko's preflight state resolution.
+    if false && [[ "$stack_choice" == "3" || "$stack_choice" == "4" || "$stack_choice" == "6" || -z "$stack_choice" ]]; then
         log_info "Starting tx spammer..."
         docker compose --profile spammer up -d tx-spammer >/dev/null 2>&1 || true
     fi

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -1122,7 +1122,9 @@ generate_prover_chain_spec() {
     local l1_beacon_docker="${L1_BEACON_HTTP_DOCKER:-http://host.docker.internal:33001}"
     local l2_rpc_docker="${L2_ENDPOINT_HTTP_DOCKER:-http://host.docker.internal:8547}"
 
-    # Generate chain spec list
+    # Generate chain spec list. The two entries below are L1 and L2 respectively — different
+    # `max_spec_id`s are intentional: L1 is Ethereum mainnet-style (CANCUN), L2 is Taiko's
+    # SHASTA fork (includes the L1STATICCALL precompile at `0x10002`).
     cat > "$CONFIGS_DIR/chain_spec_list_default.json" << EOF
 [
   {
@@ -1540,6 +1542,11 @@ generate_l2_genesis() {
 
     update_env_var "$ENV_FILE" "SHASTA_TIMESTAMP" "$HEX_TIMESTAMP"
 
+    # Requires NMC >= NethermindEth/nethermind#11017 (schema moved rip7728 /
+    # l1staticcall transition timestamps from `.params.*` to `.engine.Taiko.*`). An older
+    # NMC build will silently ignore the fields under `.engine.Taiko.*`, which causes
+    # L1SLOAD / L1STATICCALL to not activate at genesis with no error — so deploying this
+    # branch against an older NMC is a silent-fail scenario.
     cat "$SURGE_GENESIS_FILE" | jq --arg hex_timestamp "$HEX_TIMESTAMP" '. * {difficulty: 0, config: {taiko: true, londonBlock: 0, ontakeBlock: 0, pacayaBlock: 1, shastaTimestamp: $hex_timestamp, useSurgeGasPriceOracle: true, feeCollector: "0x0000000000000000000000000000000000000000", shanghaiTime: 0}} | del(.config.clique)' | jq --from-file <(curl -s https://raw.githubusercontent.com/NethermindEth/core-scripts/refs/heads/main/gen2spec/gen2spec.jq) | jq --arg hex_timestamp "$HEX_TIMESTAMP" '.engine.Taiko.shastaTimestamp = $hex_timestamp' | jq '.engine.Taiko.rip7728TransitionTimestamp = "0x0"' | jq '.engine.Taiko.l1StaticCallTransitionTimestamp = "0x0"' > "$DEPLOYMENT_DIR/surge_chainspec.json"
     
     echo
@@ -2707,10 +2714,14 @@ main() {
         log_warning "Relayer startup had issues, but continuing..."
     fi
     
-    # Step 5b: Start spammer now that L2 deploy is done (if stack option included it)
-    # DISABLED for L1STATICCALL e2e — spammer uses our test PRIVATE_KEY and its txs
-    # land in early L2 blocks with nonces that confuse raiko's preflight state resolution.
-    if false && [[ "$stack_choice" == "3" || "$stack_choice" == "4" || "$stack_choice" == "6" || -z "$stack_choice" ]]; then
+    # Step 5b: Start spammer now that L2 deploy is done (if stack option included it).
+    # Gated by ENABLE_SPAMMER (default false while L1STATICCALL e2e is in flight — the
+    # spammer currently uses the same test PRIVATE_KEY as our deploy flows, and its txs
+    # land in early L2 blocks with nonces that confuse raiko's preflight state resolution).
+    # TODO: give the spammer its own PRIVATE_KEY_SPAMMER so it can coexist with test fixtures,
+    # then flip the default to true.
+    if [[ "${ENABLE_SPAMMER:-false}" == "true" ]] \
+        && [[ "$stack_choice" == "3" || "$stack_choice" == "4" || "$stack_choice" == "6" || -z "$stack_choice" ]]; then
         log_info "Starting tx spammer..."
         docker compose --profile spammer up -d tx-spammer >/dev/null 2>&1 || true
     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     image: ${NETHERMIND_CLIENT_IMAGE}
     container_name: l2-nethermind-execution-client
     restart: unless-stopped
-    pull_policy: always
+    pull_policy: ${NETHERMIND_PULL_POLICY:-always}
     stop_grace_period: 3m
     tty: true
     volumes:
@@ -276,7 +276,7 @@ services:
     image: ${RAIKO_IMAGE}
     container_name: l2-raiko-zk-client
     restart: unless-stopped
-    pull_policy: always
+    pull_policy: ${RAIKO_PULL_POLICY:-always}
     volumes:
       - ./configs:/raiko/config
     ports:


### PR DESCRIPTION
Integrates L1STATICCALL (precompile `0x10002`) into the devnet deployment script. Similar to the L1SLOAD integration from https://github.com/NethermindEth/simple-surge-node/pull/61.

## E2E verification on devnet

L1STATICCALL runtime path (NMC + alethia-reth + L1 RPC): fully validated across three fresh devnet iterations.

Static call returns 42, tx emits event with abi-encoded 42, NMC logs `L1STATICCALL: success, l1GasUsed=23501`, dynamic gas via `debug_traceCall`, tx finalizes on L2 with `status=1`.

Test script (mirrors L1SLOAD's pattern):

```bash
set -a && source .env && set +a
cd /path/to/e2e-fixtures

# L1 fixture
L1_TARGET=$(forge create L1Target.sol:L1Target --rpc-url http://localhost:32003 --private-key $PRIVATE_KEY --broadcast --evm-version paris --legacy | awk '/Deployed to:/ {print $3}')
cast send $L1_TARGET "setValue(uint256)" 42 --rpc-url http://localhost:32003 --private-key $PRIVATE_KEY

# L2 fixture
L1_CALLER=$(forge create L1Caller.sol:L1Caller --rpc-url http://localhost:8547 --private-key $PRIVATE_KEY --broadcast --evm-version paris --legacy | awk '/Deployed to:/ {print $3}')

L1_BLOCK=$(($(cast block-number --rpc-url http://localhost:32003) - 10))

# Static sanity
cast call $L1_CALLER "readL1Value(address,uint256)(uint256)" $L1_TARGET $L1_BLOCK --rpc-url http://localhost:8547  # expect: 42

# Actual tx
cast send $L1_CALLER "callAndEmit(address,uint256,bytes)" $L1_TARGET $L1_BLOCK 0x20965255 \
  --rpc-url http://localhost:8547 --private-key $PRIVATE_KEY --gas-limit 300000
```

## Cross references

- NMC L1STATICCALL precompile + witness RPC: https://github.com/NethermindEth/nethermind/pull/11017
- NMC block-range validation follow-up: https://github.com/NethermindEth/nethermind/pull/11275
- alethia-reth L1STATICCALL: https://github.com/NethermindEth/alethia-reth/pull/13
- surge-raiko L1STATICCALL: https://github.com/NethermindEth/raiko/pull/63
- surge-taiko-mono integration tests: https://github.com/NethermindEth/surge-taiko-mono/pull/285 and https://github.com/NethermindEth/surge-taiko-mono/pull/288
- L1SLOAD precedent: https://github.com/NethermindEth/simple-surge-node/pull/61
