### PR TITLE
Wire L1 precompiles into real-time devnet

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -20,10 +20,10 @@
 
 ############################### IMAGES #####################################
 PROTOCOL_IMAGE=nethermind/surge-protocol:v26.0.1
-NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master
+NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-ec87b31
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:v26.0.1
 CATALYST_IMAGE=nethermind/catalyst-node:latest
-RAIKO_IMAGE=nethermind/surge-raiko-mock:v26.0.1-surge
+RAIKO_IMAGE=nethermind/surge-raiko-mock:sha-eb6e14f
 
 ############################### L1 NETWORK #####################################
 L1_CHAIN_ID=3151908

--- a/.env.devnet
+++ b/.env.devnet
@@ -23,7 +23,7 @@ PROTOCOL_IMAGE=nethermind/surge-protocol:v26.0.1
 NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-ec87b31
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:v26.0.1
 CATALYST_IMAGE=nethermind/catalyst-node:latest
-RAIKO_IMAGE=nethermind/surge-raiko-mock:sha-9ce0bca
+RAIKO_IMAGE=nethermind/surge-raiko-mock:v26.1.0-surge
 
 ############################### L1 NETWORK #####################################
 L1_CHAIN_ID=3151908

--- a/.env.devnet
+++ b/.env.devnet
@@ -23,7 +23,7 @@ PROTOCOL_IMAGE=nethermind/surge-protocol:v26.0.1
 NETHERMIND_CLIENT_IMAGE=nethermindeth/nethermind:master-ec87b31
 TAIKO_CLIENT_IMAGE=nethermind/taiko-client:v26.0.1
 CATALYST_IMAGE=nethermind/catalyst-node:latest
-RAIKO_IMAGE=nethermind/surge-raiko-mock:sha-eb6e14f
+RAIKO_IMAGE=nethermind/surge-raiko-mock:sha-9ce0bca
 
 ############################### L1 NETWORK #####################################
 L1_CHAIN_ID=3151908

--- a/deploy-surge-full.sh
+++ b/deploy-surge-full.sh
@@ -1032,6 +1032,8 @@ generate_l2_genesis() {
             '. * {difficulty: 0, config: {taiko: true, londonBlock: 0, ontakeBlock: 0, pacayaBlock: 1, shastaTimestamp: $hex_timestamp, feeCollector: "0x0000000000000000000000000000000000000000", shanghaiTime: 0}} | del(.config.clique)' \
         | jq --from-file "$gen2spec_file" \
         | jq --arg hex_timestamp "$HEX_TIMESTAMP" '.engine.Taiko.shastaTimestamp = $hex_timestamp' \
+        | jq '.engine.Taiko.rip7728TransitionTimestamp = "0x0"' \
+        | jq '.engine.Taiko.l1StaticCallTransitionTimestamp = "0x0"' \
         > "$DEPLOYMENT_DIR/surge_chainspec.json"
 
     rm -f "$gen2spec_file"
@@ -1045,7 +1047,7 @@ generate_l2_genesis() {
     # Clean up any leftover container from a previous run
     docker rm -f nethermind-genesis-hash 2>/dev/null || true
     # Get genesis hash first by running Nethermind with the chainspec
-    docker run -d --name nethermind-genesis-hash -v ./deployment/surge_chainspec.json:/chainspec.json nethermindeth/nethermind:taiko-shasta-changes --config=none --Init.ChainSpecPath=/chainspec.json
+    docker run -d --name nethermind-genesis-hash -v ./deployment/surge_chainspec.json:/chainspec.json "${NETHERMIND_CLIENT_IMAGE:-nethermindeth/nethermind:master}" --config=none --Init.ChainSpecPath=/chainspec.json --Surge.L1EthApiEndpoint="${L1_ENDPOINT_HTTP:-http://localhost:32003}"
     
     log_info "Waiting for Nethermind to output genesis hash (up to 60s)..."
     local waited=0

--- a/script/start-nethermind.sh
+++ b/script/start-nethermind.sh
@@ -17,6 +17,7 @@ ARGS="${ARGS} \
     --datadir=/data/surge \
     --Init.ChainSpecPath=/chainspec.json \
     --Init.GenesisHash=${L2_GENESIS_HASH} \
+    --Surge.L1EthApiEndpoint=${L1_ENDPOINT_HTTP:-http://localhost:32003} \
     --Metrics.Enabled=true \
     --Metrics.ExposePort=${L2_METRICS_PORT} \
     --JsonRpc.Enabled=true \


### PR DESCRIPTION
Active both L1SLOAD and L1STATICCALL precompiles at L2 genesis on real-time proving, and so NMC can come up under that configuration.

Companion PRs:
- https://github.com/NethermindEth/raiko/pull/67
- https://github.com/NethermindEth/alethia-reth/pull/14